### PR TITLE
Untar Xilinx install package using ssh & tar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ ARG HOST_LOGIN
 RUN ssh -oStrictHostKeyChecking=no ${HOST_LOGIN} -i id_rsa "cat ~/Downloads/Xilinx_Vivado_SDK_2016.1_0409_1.tar.gz -" | tar xzv && \
   /Xilinx_Vivado_SDK_2016.1_0409_1/xsetup --agree 3rdPartyEULA,WebTalkTerms,XilinxEULA --batch Install --config install_config.txt && \
   rm -rf Xilinx_Vivado_SDK_2016.1_0409_1 && \
-  rm id_rsa
+  rm id_rsa && \
+  rm /root/.ssh/known_hosts
 
 #make a Vivado user
 RUN adduser --disabled-password --gecos '' vivado

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,7 @@ RUN apt-get update && apt-get install -y \
   libfontconfig \
   git
 
-#Copy in Vivado installer and config file
-# TODO: is there any way to save image size here?
+#Copy in config file and ssh private key
 COPY install_config.txt /
 COPY id_rsa /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM ubuntu:14.04
 
 MAINTAINER Colm Ryan <cryan@bbn.com>
 
+# build with docker build --build-arg HOST_LOGIN=user@host --rm -t vivado .
+
+
 #install dependences for:
 # * xsim (gcc build-essential to also get make)
 # * MIG tool (libglib2.0-0 libsm6 libxi6 libxrender1 libxrandr2 libfreetype6 libfontconfig)
@@ -19,11 +22,15 @@ RUN apt-get update && apt-get install -y \
 
 #Copy in Vivado installer and config file
 # TODO: is there any way to save image size here?
-ADD Xilinx_Vivado_SDK_2016.1_0409_1.tar.gz /
-COPY install_config.txt /Xilinx_Vivado_SDK_2016.1_0409_1/
+COPY install_config.txt /
+COPY id_rsa /
 
 #run the install
-RUN /Xilinx_Vivado_SDK_2016.1_0409_1/xsetup --agree 3rdPartyEULA,WebTalkTerms,XilinxEULA --batch Install --config /Xilinx_Vivado_SDK_2016.1_0409_1/install_config.txt
+ARG HOST_LOGIN
+RUN ssh -oStrictHostKeyChecking=no ${HOST_LOGIN} -i id_rsa "cat ~/Downloads/Xilinx_Vivado_SDK_2016.1_0409_1.tar.gz -" | tar xzv && \
+  /Xilinx_Vivado_SDK_2016.1_0409_1/xsetup --agree 3rdPartyEULA,WebTalkTerms,XilinxEULA --batch Install --config install_config.txt && \
+  rm -rf Xilinx_Vivado_SDK_2016.1_0409_1 && \
+  rm id_rsa
 
 #make a Vivado user
 RUN adduser --disabled-password --gecos '' vivado

--- a/README.md
+++ b/README.md
@@ -4,12 +4,14 @@ Vivado installed into a docker image for CI purposes.
 
 ## Build instructions
 
-1. Copy the Vivado installer (Xilinx_Vivado_SDK_2015.3_0929_1.tar.gz) file into the directory.
-1. Copy your Vivado `Xilinx.lic` file into the directory.
-2. Potentialy modify the `install_config.txt` to change the install options.
-3. Build the image (will take about 10 minutes)
+1. This docker file assumes your Vivado installer is available on a host a ~/Downloads/Xilinx_Vivado_SDK_2016.1_0409_1.tar.gz
+2. Create a password-less ssh rsa key `ssh-keygen -t rsa`
+3. Copy resulting private key (`~/.ssh/id_rsa`) into the directory
+4. Copy your Vivado `Xilinx.lic` file into the directory.
+5. Potentialy modify the `install_config.txt` to change the install options.
+6. Build the image (will take about 10 minutes) passing in a build arg
     ```shell
-    docker build -t caryan/vivado:2016.1 .
+    docker build --build-arg HOST_LOGIN=user@host --rm -t vivado:2016.1 .
     ```
 
 ## Running


### PR DESCRIPTION
This PR replaces the ADD command to copy in and untar the Xilinux install package with a `ssh | tar` combination and then removal of the installer. This results in a docker image which is 8.2 GB on my machine rather than the 20.5 GB using the ADD method. A password-less ssh key pair is required. The private key is copied into the container and then both the key and the ssh `known_hosts` files are removed. 
